### PR TITLE
Fix error when a bucket is disabled

### DIFF
--- a/public/components/network_vis.tsx
+++ b/public/components/network_vis.tsx
@@ -122,11 +122,11 @@ export const NetworkVis = ({ vis, visData, visParams}) => {
   const getColumnIdByAggId = (aggId) => {
     return visData.columns?.find((col) => {
       return col.id.split('-')[2] === aggId;
-    }).id;
+    })?.id;
   };
 
   function getColumnNameFromColumnId(columnId) {
-    return visData.columns?.find(colObj => colObj.id === columnId).name;
+    return visData.columns?.find(colObj => colObj.id === columnId)?.name;
   }
 
   function getData() {
@@ -140,10 +140,10 @@ export const NetworkVis = ({ vis, visData, visParams}) => {
         // This might look confusing in a tooltip, so only the term name is used here
         if (firstFirstBucketId) {
           firstSecondBucketId = getColumnIdByAggId(agg.id);
-          secondaryNodeTermName = getColumnNameFromColumnId(firstSecondBucketId).split(':')[0];
+          secondaryNodeTermName = getColumnNameFromColumnId(firstSecondBucketId)?.split(':')[0];
         } else {
           firstFirstBucketId = getColumnIdByAggId(agg.id);
-          primaryNodeTermName = getColumnNameFromColumnId(firstFirstBucketId).split(':')[0];
+          primaryNodeTermName = getColumnNameFromColumnId(firstFirstBucketId)?.split(':')[0];
         }
       } else if (agg.schema === 'second') {
         secondBucketId = getColumnIdByAggId(agg.id);

--- a/releases/unreleased/fix-error-when-a-bucket-is-disabled.yml
+++ b/releases/unreleased/fix-error-when-a-bucket-is-disabled.yml
@@ -1,0 +1,8 @@
+---
+title: Fix error when a bucket is disabled
+category: fixed
+author: Eva Millán <evamillan@bitergia.com>
+issue: 6
+notes: >
+  The visualization no longer fails to load when a bucket
+  is disabled.


### PR DESCRIPTION
This PR changes the functions that process the visualization's data to prevent them from throwing an error when a value from a disabled bucket is missing.
Fixes #6.