### PR TITLE
Update OpenSearch version to 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 npm-debug.log
+target/

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "networkVisPlugin",
   "version": "0.39.0",
-  "opensearchDashboardsVersion": "3.2.0",
+  "opensearchDashboardsVersion": "3.6.0",
   "server": false,
   "ui": true,
   "requiredPlugins": [

--- a/releases/unreleased/upgrade-to-opensearch-dashboards-360.yml
+++ b/releases/unreleased/upgrade-to-opensearch-dashboards-360.yml
@@ -1,0 +1,7 @@
+---
+title: Upgrade to OpenSearch Dashboards 3.6.0
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  Upgrade plugin compatibility with OpenSearch Dashboards 3.6.0


### PR DESCRIPTION
This PR updates the version of OpenSearch Dashboards to 3.6.0.